### PR TITLE
Fix for Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
-sudo: required
-dist: trusty
-language: perl
+sudo: false
+language: "perl"
 before_install:
-    - npm install -g dredd
-    - bundle install
+  - "npm install -g dredd"
+  - "bundle install"
 script:
-    - perl Build.PL && ./Build build && ./Build test
-    - ./Build install
-    - bundle exec cucumber
+  - "perl Build.PL && ./Build build && ./Build test"
+  - "./Build install"
+  - "bundle exec cucumber"
 perl:
   - "5.18"
   - "5.20"


### PR DESCRIPTION
Addressing https://github.com/ungrim97/Dredd-Hooks/issues/3. Since Dredd doesn't need C++ compiler anymore (see https://github.com/ungrim97/Dredd-Hooks/pull/2#issuecomment-234653942), I tried to switch back to Travis' container-based infrastructure and everything seems to work again 🎉 

I don't know what they did on Travis to break the Perl builds, but this resolved the issue at least for Dredd::Hooks 🐫
